### PR TITLE
Log errors to the last used channel

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -6,11 +6,6 @@ config.load();
 const ChatHandler = require("./chathandler");
 const CommandsLib = require("./commands");
 
-//Make sure all exceptions don't kill the bot
-process.on('uncaughtException', (err) => {
-    console.error(err.stack);
-});
-
 // Create an instance of a Discord client
 const client = new Client({
     intents: [

--- a/bot.js
+++ b/bot.js
@@ -51,9 +51,9 @@ client.on("disconnect", function() {
 })
 
 // Create an event listener for messages
-client.on('messageCreate', message => {
+client.on('messageCreate', async message => {
     if (client.user.id != message.author.id) {
-        ChatHandler.handle(message.content, message.author, message.channel, message);
+        await ChatHandler.handle(message.content, message.author, message.channel, message);
     }
 });
 

--- a/bot.js
+++ b/bot.js
@@ -57,6 +57,20 @@ client.on('messageCreate', async message => {
     }
 });
 
+process.on('uncaughtException', handleException);
+process.on('unhandledRejection', handleException);
+
+async function handleException(e) {
+    console.error(e);
+    if (client.lastUsedChannel !== undefined) {
+        try {
+            await client.lastUsedChannel.send("An error has occured! `" + e + "`");
+        } catch(e) {
+            console.warn("Couldn't log error to lastUsedChannel: ", e);
+        }
+    } else console.warn("No last used channel to log the error to!");
+}
+
 // Log our bot in
 client.login(token);
 

--- a/chathandler.js
+++ b/chathandler.js
@@ -4,6 +4,7 @@ var http = require("http");
 var config = require("./config");
 var discord = require("discord.js");
 const commandsLib = require("./commands");
+const { client } = require("./bot");
 
 const reloadEvents = [];
 
@@ -26,6 +27,7 @@ async function handle(message, sender, channel, msgobj) {
 		//This cuts the first arg off and splits the rest
 		var args = message.substr(message.substr(pre.length).split(" ")[0].length + pre.length + (message.indexOf(' ') != -1 ? 1 : 0)).split(" ");
 		try {
+			msgobj.client.lastUsedChannel = channel;
 			await handleCommand(message.substr(config.getCommandPrefix().length).split(" ")[0], args, sender, channel, msgobj);
 		} catch (exception) {
 			console.log(exception);
@@ -40,6 +42,7 @@ async function handle(message, sender, channel, msgobj) {
 			
 			var exp = new RegExp(key, "i");
 			if (exp.test(message)) {
+				msgobj.client.lastUsedChannel = channel;
 				await send(channel, sender, msg);
 				break;
 			}
@@ -57,7 +60,7 @@ async function handleCommand(command, args, sender, channel, msgobj) {
 			config.load();
 			commandsLib.loadCommands();
 			for (callback of reloadEvents) {
-				callback();
+				await callback();
 			}
 			const size = await fetchChatStuff();
 			await send(channel, sender, "Reload successful! Loaded " + size + " regex commands!");

--- a/chathandler.js
+++ b/chathandler.js
@@ -9,12 +9,10 @@ const reloadEvents = [];
 
 var parentM;
 
-var barred = [];
-
 const emoji_tickbox = "\u2705";
 const emoji_cross = "\u274C";
 
-function handle(message, sender, channel, msgobj) {
+async function handle(message, sender, channel, msgobj) {
 	//var isOp = sender.id == "145436402107154433"; //ID of the owner of the bot
 	var isOp = config.isOp(sender.id);
 	const pre = config.getCommandPrefix();
@@ -28,10 +26,10 @@ function handle(message, sender, channel, msgobj) {
 		//This cuts the first arg off and splits the rest
 		var args = message.substr(message.substr(pre.length).split(" ")[0].length + pre.length + (message.indexOf(' ') != -1 ? 1 : 0)).split(" ");
 		try {
-			handleCommand(message.substr(config.getCommandPrefix().length).split(" ")[0], args, sender, channel, msgobj);
+			await handleCommand(message.substr(config.getCommandPrefix().length).split(" ")[0], args, sender, channel, msgobj);
 		} catch (exception) {
 			console.log(exception);
-			send(channel, sender, "An error occurred while running this command. Please check the console.")
+			await send(channel, sender, "An error occurred while running this command. Please check the console.")
 		}
 		
 		
@@ -42,52 +40,51 @@ function handle(message, sender, channel, msgobj) {
 			
 			var exp = new RegExp(key, "i");
 			if (exp.test(message)) {
-				send(channel, sender, msg);
+				await send(channel, sender, msg);
 				break;
 			}
 		}
 	}
 }
 
-function handleCommand(command, args, sender, channel, msgobj) {
+async function handleCommand(command, args, sender, channel, msgobj) {
 	if (config.isOp(sender.id)) { //Temp - Will be moved to files later
 		if (command == "debug") {
-			channel.send(channel, sender, "Author: " + sender + ", ID: " + sender.id)
+			await channel.send(channel, sender, "Author: " + sender + ", ID: " + sender.id)
 			return;
 		} else if (command == "reload") {
-			send(channel, sender, "Reloading... one moment");
+			await send(channel, sender, "Reloading... one moment");
 			config.load();
 			commandsLib.loadCommands();
 			for (callback of reloadEvents) {
 				callback();
 			}
-			fetchChatStuff(function(size) {
-				send(channel, sender, "Reload successful! Loaded " + size + " regex commands!");
-			});
+			const size = await fetchChatStuff();
+			await send(channel, sender, "Reload successful! Loaded " + size + " regex commands!");
 			return;
 		} else if (command == "latency") {
-			send(channel, sender, "Current ping: " + parentM.client.ping);
+			await send(channel, sender, "Current ping: " + parentM.client.ping);
 			return;
 		} else if (command == "bar") {
 			if (msgobj.mentions.users.size == 0) {
-				sender.send("Incorrect usage! Make sure you specify a user! Usage: `!bar @user`");
-				msgobj.react(emoji_cross).catch(o=>{});
+				await sender.send("Incorrect usage! Make sure you specify a user! Usage: `!bar @user`");
+				await msgobj.react(emoji_cross);
 			} else {
 				for (var [id, user] of msgobj.mentions.users) {
 					config.barUser(id);
 				}
-				msgobj.react(emoji_tickbox).catch(o=>{});
+				await msgobj.react(emoji_tickbox);
 			}
 			return;
 		} else if (command == "unbar") {
 			if (msgobj.mentions.users.size == 0) {
-				sender.send("Incorrect usage! Make sure you specify a user! Usage: `!unbar @user`");
-				msgobj.react(emoji_cross).catch(o=>{});;
+				await sender.send("Incorrect usage! Make sure you specify a user! Usage: `!unbar @user`");
+				await msgobj.react(emoji_cross);
 			} else {
 				for (var [id, user] of msgobj.mentions.users) {
 					config.unbarUser(id);
 				}
-				msgobj.react(emoji_tickbox).catch(o=>{});;
+				await msgobj.react(emoji_tickbox);
 			}
 			return;
 		}
@@ -96,7 +93,7 @@ function handleCommand(command, args, sender, channel, msgobj) {
 
 	if (commandsLib.isCommand(command)) {
 		if (commandsLib.canUseCommand(command, sender)) {
-			commandsLib.runCommand(command, sender, msgobj);
+			await commandsLib.runCommand(command, sender, msgobj);
 		}
 	}
 
@@ -105,40 +102,36 @@ function handleCommand(command, args, sender, channel, msgobj) {
 /**
  * Fetches all chat stuff 
  */
-function fetchChatStuff(callback) {
+async function fetchChatStuff() {
 	chatMap.clear();
 	
-	request(config.getURL(), function(html) {
-		for (var i in html.split("\n")) {
-			var line = html.split("\n")[i];
-			if (line.lastIndexOf(config.getSplit()) !== -1) { //If line contains '>>'
-				var regex = line.substr(0, line.lastIndexOf(config.getSplit())); //Get the first part of the string
-				var line = line.substr(line.lastIndexOf(config.getSplit()) + config.getSplit().length, line.length); //Get the last part of the string
-				
-				regex = regex.trim(); //Removes extra spaces
-				line = line.trim();
-				
-				chatMap.set(regex, line);
-				console.log("Registered #" + chatMap.size + " regex command");
-			}
+	const html = await request(config.getURL());
+	for (var line of html.split("\n")) {
+		if (line.lastIndexOf(config.getSplit()) !== -1) { //If line contains '>>'
+			var regex = line.substr(0, line.lastIndexOf(config.getSplit())); //Get the first part of the string
+			var line = line.substr(line.lastIndexOf(config.getSplit()) + config.getSplit().length, line.length); //Get the last part of the string
+			
+			regex = regex.trim(); //Removes extra spaces
+			line = line.trim();
+			
+			chatMap.set(regex, line);
+			console.log("Registered #" + chatMap.size + " regex command");
 		}
-		
-		console.log("Finished loading regex expressisons!");
-		
-		
-		if (typeof callback !== "undefined") {
-			callback(chatMap.size);
-		}
-	});
+	}
+	
+	console.log("Finished loading regex expressisons!");
+	
+	
+	return chatMap.size;
 }
 
 /**
  * Send a message to a person. Depending on the channel, it may
  * be send via the channel or via DM.
  */
-function send(channel, sender, message) {
+async function send(channel, sender, message) {
 	if (!(channel instanceof discord.TextChannel)) { //If it's not a text channel, just reply. For group DMs or single DMs
-		channel.send(message);
+		await channel.send(message);
 		return;
 	}
 	
@@ -151,9 +144,9 @@ function send(channel, sender, message) {
 	}
 	
 	if (loud) { //If the bot is allowed to be voiced in the channel
-		channel.send(message);
+		await channel.send(message);
 	} else if (quiet) { //DM them the message if the bot can't reply to the channel
-		sender.send(message);
+		await sender.send(message);
 	} else {
 		throw Exception("wtf is going on here?!?");
 	}
@@ -170,7 +163,7 @@ function isChannelIgnored(channel) {
  * Makes an HTTP request to the given url and
  * calls callback(html)
  */
-function request(url, callback) {
+function request(url) {
 	if (url.startsWith("https://")) url = url.substr(8);
 	else if (url.startsWith("http://")) url = url.substr(7);
 	
@@ -179,24 +172,26 @@ function request(url, callback) {
 	tempArray.reverse().pop();
 	tempArray.reverse();
 	var path = "/" + tempArray.join("/");
-	
+		
 	//console.log("URL BASE: " + urlbase);
 	//console.log("Path: " + path);
-	
-	http.get({
-		hostname: urlbase,
-		path: path,
-		agent: false
-	}, (response) => {
-		var body = '';
-		response.on('data', function(d) {
-            body += d;	
-            //console.log("HTTP REQUEST GOT: " + d)
-        });
-		response.on('end', function() {
-			callback(body);
+
+	return new Promise((res, rej) => { // TODO: handle errors, use rej
+		http.get({
+			hostname: urlbase,
+			path: path,
+			agent: false
+		}, (response) => {
+			var body = '';
+			response.on('data', function(d) {
+				body += d;	
+				//console.log("HTTP REQUEST GOT: " + d)
+			});
+			response.on('end', function() {
+				res(body);
+			});
 		});
-	})
+	});
 }
 exports.handle = handle;
 exports.fetchChatStuff = fetchChatStuff;

--- a/commands.js
+++ b/commands.js
@@ -55,14 +55,14 @@ function canUseCommand(command, sender) {
 	return isCommand(command) && getCommand(command).canUse(sender);
 }
 
-function runCommand(command, sender, message) {
+async function runCommand(command, sender, message) {
 	//This cuts the first arg off and splits the rest
 	const msg = message.content;
 	var args = msg.substr(msg.substr(PREFIX.length).split(" ")[0].length + PREFIX.length + (msg.indexOf(' ') != -1 ? 1 : 0)).split(" ");
 		
 	try {
 		console.log("[#" + message.channel.name + "] " + message.author.username + ": " + message.content);
-		getCommand(command).run(message, message.channel, sender, args);
+		return await getCommand(command).run(message, message.channel, sender, args);
 	} catch (e) {
 		console.log(e);
 	}

--- a/modules/autoreactor.js
+++ b/modules/autoreactor.js
@@ -1,6 +1,7 @@
 const API = require("../api");
 const FS = require("fs");
-const { ThreadChannel, ForumChannel } = require("discord.js")
+const { ThreadChannel, ForumChannel } = require("discord.js");
+const { client } = require("../bot");
 
 let reactionList = [];
 const file = "./config/autoreactor.json";
@@ -25,11 +26,18 @@ async function onTextMessage(message) {
         } else return; 
     }
 
+    if (message.author.id === message.client.user.id) {
+        return; // ignore the message if the message is sent by the bot
+    }
+
     //Loop through all reactions we have in the reaction config
     for (reactionObj of reactionList) {
         
          //If the channel ID or channel name is equal to the channel specified
         if (channel.id === reactionObj.channel || channel.name === reactionObj.channel) {
+
+            message.client.lastUsedChannel = channel;
+
             //If they have multiple reactions to give
             if (reactionObj.reactions) { 
                 for (emoji of reactionObj.reactions) {


### PR DESCRIPTION
* Use promises throughout the code, so that we can minimize the amount of unhandled rejections and shift the burden of handling errors to the parent function
* Maintain a variable `client.lastUsedChannel` and send errors to that channel when `unhandledRejection` and `uncaughtException` events are fired, resolving #10
Resolves #10 