### PR TITLE
[Bugfix] Fix canUse always returning a truthful value

### DIFF
--- a/api.js
+++ b/api.js
@@ -172,7 +172,7 @@ async function getMessage(snowflake, context = undefined) {
  * @param {Snowflake|String} snowflake 
  * @returns True if they are an op
  */
-async function isOp(snowflake) {
+function isOp(snowflake) {
     return config.isOp(getId(snowflake));
 }
 

--- a/commands/echo.js
+++ b/commands/echo.js
@@ -15,7 +15,7 @@ module.exports = {
     name: "echo",
     usage: "echo <channel> <message>",
     description: "Send a message to a channel",
-    canUse: async function(sender) {
+    canUse: function(sender) {
         return isOp(sender.id);
     },
     run: async function(messageObj, channel, sender, args) {

--- a/commands/echoedit.js
+++ b/commands/echoedit.js
@@ -16,7 +16,7 @@ module.exports = {
     name: "echoedit",
     usage: "echoedit <message_id> <new message>",
     description: "Edit a message sent by the bot",
-    canUse: async function(sender) {
+    canUse: function(sender) {
         return isOp(sender.id);
     },
     run: async function(messageObj, channel, sender, args) {


### PR DESCRIPTION
Currently, both of the available commands' `canUse` methods return promises (as they're async). Additionally, when the `canUse` method is called in other files of the project, the returned promise is not awaited, or handled properly in another way, but rather the direct return value (the promise itself) is used to check whether a command is usable in a given context.
The problem is, promises are truthful values:
```
> Boolean(new Promise((res,rej)=>{}))
true
> Boolean(Promise.resolve("hey"))
true
> Boolean(Promise.reject("hey"))
true
...
> Boolean(async () => {throw 'a';})
true
```
And this results in the commands library, or the `chathandler` assuming the command is usable when it is not.
To avoid this issue, this PR removes the `async` keyword from the `canUse` methods.

Both of the commands' `canUse` methods return the return value of `config.isOp`, which also returns a promise. This PR removes the `async` keyword from the `config.isOp` function to make it return a boolean. This function doesn't perform any actions that require asynchronicity anyway