### PR TITLE
Handle disposal of old collectors properly

### DIFF
--- a/modules/autoresponses.js
+++ b/modules/autoresponses.js
@@ -32,8 +32,8 @@ class ButtonResponse {
             if (old.timeoutId != -1) 
                 clearTimeout(old.timeoutId); //Remove the timeout ask of the old one
             
-            for (let coll of this.collectors) {
-                coll.dispose(); //Remove the old collectors
+            for (let coll of old.collectors) {
+                coll.stop(); //Remove the old collectors
             }
         }
 


### PR DESCRIPTION
The for loop iterated over `this.collectors`, which is always an empty array at that point of the code. `InteractionCollector#dispose()` takes an interaction as a parameter, the method you're looking for is probably `#end()`.
Fixes #7 