### PR TITLE
- Adds a simpler regex check for the initial detection of stacktraces…

### DIFF
--- a/config/autoresponses/jedcore.json
+++ b/config/autoresponses/jedcore.json
@@ -3,10 +3,10 @@
         "^\\.jedcore",
         "(((where|can (i|someone)).+(link.+to|find|download|get).+jed ?core)|(where.+(is|did).+jed ?core)|(can.{0,3}t.+(find).+jed ?core))[?!.]{0,5}"
     ],
-    "response": "JedCore is currently maintained by Aztl and is avaliable via GitHub. Click the button bellow for a link",
+    "response": "JedCore is currently maintained by Cozmyc and is avaliable via GitHub. Click the button bellow for a link",
     "buttons": [
         "GitHub Page",
-        "https://github.com/Aztlon/JedCore/releases"
+        "https://github.com/CozmycDev/JedCore/releases"
     ]
 
 }]

--- a/core/modules/openai_llm.js
+++ b/core/modules/openai_llm.js
@@ -4,7 +4,8 @@ const fs = require('fs');
 var config = require("../config.js");
 const API = require("../api.js");
 
-const logFiles = config["file-logging"] || false;
+const settings = JSON.parse(fs.readFileSync('./config/stacktrace_config.json', 'utf8'));
+const logFiles = settings["file-logging"] || false;
 
 const LLM_MODEL = 'gpt-4o-mini'; // best and most affordable openai model for stack trace analysis
 const BASE_PROMPT = fs.readFileSync('./config/base_stacktrace_prompt.txt', 'utf8');

--- a/core/modules/openai_llm.js
+++ b/core/modules/openai_llm.js
@@ -3,7 +3,8 @@ const tiktoken = require('tiktoken');
 const fs = require('fs');
 var config = require("../config.js");
 const API = require("../api.js");
-const { logFiles } = require("./stacktrace_analyzer.js");
+
+const logFiles = config["file-logging"] || false;
 
 const LLM_MODEL = 'gpt-4o-mini'; // best and most affordable openai model for stack trace analysis
 const BASE_PROMPT = fs.readFileSync('./config/base_stacktrace_prompt.txt', 'utf8');

--- a/core/modules/stacktrace_analyzer.js
+++ b/core/modules/stacktrace_analyzer.js
@@ -229,6 +229,7 @@ async function sendStackTraceResponse(message, analysisResult, tokens, responseT
             const memberRoles = interaction.member.roles.cache;
             const staffRoles = configJS.getRoles('staff');
             const isStaff = memberRoles.some(role => staffRoles.includes(role.id));
+            const isNotAuthor = interaction.user.id !== msgobj.author.id;
 
             const responseEmbed = new EmbedBuilder()
                 .setTitle("Stack Trace Analyzer")
@@ -242,7 +243,7 @@ async function sendStackTraceResponse(message, analysisResult, tokens, responseT
                 }
 
             if (userAccepted) {
-                if (isStaff) {
+                if (isStaff && isNotAuthor) {
                     // keeps the buttons for the user to still use if staff responds first
                     responseEmbed.setFooter({ text: `A staff member accepted this response. ✅` });
                     await interaction.update({ embeds: [responseEmbed], components: [actionRow] });
@@ -252,7 +253,7 @@ async function sendStackTraceResponse(message, analysisResult, tokens, responseT
                     await interaction.update({ embeds: [responseEmbed], components: [] });
                 }
             } else {
-                if (isStaff) {
+                if (isStaff && isNotAuthor) {
                     responseEmbed.setFooter({ text: `A staff member marked this response as not helpful. ❌` });
                     await interaction.update({ embeds: [responseEmbed], components: [actionRow] });
                 } else {

--- a/core/modules/stacktrace_analyzer.js
+++ b/core/modules/stacktrace_analyzer.js
@@ -127,7 +127,7 @@ async function handleStackTrace(message, sender, channel, msgobj) {
         // log matches for debugging
         console.log("Matches:", groups);
 
-        if (groups.length <= 0) {
+        if (!groups || groups.length === 0) {
             console.log("No matches found.");
             return;
         }

--- a/core/modules/stacktrace_analyzer.js
+++ b/core/modules/stacktrace_analyzer.js
@@ -4,10 +4,10 @@ const configJS = require('../config.js');
 
 const config = JSON.parse(fs.readFileSync('config/stacktrace_config.json', 'utf8'));
 
-const enabled = config["enabled"] || true;
-const logFiles = config["file-logging"] || false;
+const enabled = config["enabled"] ?? true;
+const logFiles = config["file-logging"] ?? false;
 
-const includeTokenCounts = config["show-tokens"] || false;
+const includeTokenCounts = config["show-tokens"] ?? false;
 
 // stack trace analysis
 const devSupportChannel = config["developer-channels"];  // add the dev support channel ID here to let the LLM know when its a dev request
@@ -16,10 +16,6 @@ const { getGPTInstance, BASE_PROMPT } = require('./openai_llm.js');
 const { extractTextFromImage } = require('./ocr.js');
 const API = require('../api.js');
 const { EmbedBuilder, MessageAttachment, ActionRowBuilder, ButtonBuilder, ButtonStyle, Events, PermissionsBitField } = require('discord.js');
-
-
-// here for debugging
-
 
 // regex for detecting stack traces and image urls (with resources) in messages and screenshots
 const imageUrlRegex = /(https?:\/\/[^\s]+(?:\.(?:jpg|jpeg|png))(?:\?[^\s]*)?)/i;
@@ -287,6 +283,9 @@ module.exports = {
     checkForStackTrace,
     logFiles
 }
+
+if (enabled) console.log("Enabled Stack Trace Analyzer");
+else console.log("Stack Trace Analyzer not active");
 
 API.subscribe("reload", () => {
     config = JSON.parse(fs.readFileSync('../../config/stacktrace_config.json', 'utf8'));

--- a/core/modules/stacktrace_analyzer.js
+++ b/core/modules/stacktrace_analyzer.js
@@ -147,8 +147,8 @@ async function handleStackTrace(message, sender, channel, msgobj) {
         const tokens = await openAIClient.countTokens(prompt);
         console.log("Prompt Tokens:", tokens)
 
-        // safety net of 3500 tokens, or ~2625 words/symbols
-        if (tokens >= 3500) {
+        // safety net
+        if (tokens >= 6500) {
             const embed = new EmbedBuilder()
                 .setTitle("Stack Trace Analyzer")
                 .setDescription("I detected a stack trace in your message but it is too long for me to process.\nPlease find and paste the exact stack trace you would like me to analyze for you.")


### PR DESCRIPTION
- Adds a simpler regex check for the initial detection of stack traces; then uses the full regex for extracting the stack trace. The simple regex first case sensitive checks the text for WARN, ERROR, or INFO, if it contains those words, then its passed to the more complex regex to extract the stack trace. If the more complex regex finds nothing then the message should be ignored. This isnt infallible.
- Fixes a circular import issue.
- Raises the prompt token limit to 6500. For some reason on the PK server it seemed prompts were somehow longer than expected or something compared to tests.