### PR TITLE
added airbug auto response

### DIFF
--- a/config/autoresponses/commands-list.json
+++ b/config/autoresponses/commands-list.json
@@ -1,4 +1,4 @@
 {
     "trigger": "^\\.commands",
-    "response": "Command List:\n`.troubleshoot`\n`.jedcore`\n`.spirits`\n`.addons`\n`.download`\n`.perms`\n`.luckperms`\n`.arclight`\n`.usage`\n`.flight`\n`.blood`\n`.bedrock`\n`.singleplayer`\n`.serverlist\n`.airbug``"
+    "response": "Command List:\n`.troubleshoot`\n`.jedcore`\n`.spirits`\n`.addons`\n`.download`\n`.perms`\n`.luckperms`\n`.arclight`\n`.usage`\n`.flight`\n`.blood`\n`.bedrock`\n`.singleplayer`\n`.serverlist`\n`.airbug`"
 }

--- a/config/autoresponses/commands-list.json
+++ b/config/autoresponses/commands-list.json
@@ -1,4 +1,4 @@
 {
     "trigger": "^\\.commands",
-    "response": "Command List:\n`.troubleshoot`\n`.jedcore`\n`.spirits`\n`.addons`\n`.download`\n`.perms`\n`.luckperms`\n`.arclight`\n`.usage`\n`.flight`\n`.blood`\n`.bedrock`\n`.singleplayer`\n`.serverlist`"
+    "response": "Command List:\n`.troubleshoot`\n`.jedcore`\n`.spirits`\n`.addons`\n`.download`\n`.perms`\n`.luckperms`\n`.arclight`\n`.usage`\n`.flight`\n`.blood`\n`.bedrock`\n`.singleplayer`\n`.serverlist\n`.airbug``"
 }

--- a/config/autoresponses/troubleshoot/plugin/airbug.json
+++ b/config/autoresponses/troubleshoot/plugin/airbug.json
@@ -1,0 +1,7 @@
+{
+    "triggers": [
+        "^\\.airbug",
+        "^\\.airparticles"
+    ],
+    "response": "If you are on minecraft 1.21.9+. make sure `plugins\\Projectkorra\\config.yml`. Has Path `Air.Particles` set to `CLOUD`. then save and run `\\b reload`."
+}

--- a/config/autoresponses/troubleshoot/plugin/error/error.json
+++ b/config/autoresponses/troubleshoot/plugin/error/error.json
@@ -10,6 +10,8 @@
         "When logging in",
         "troubleshoot/plugin/error/other.json",
         "Other",
-        "troubleshoot/plugin/error/other.json"
+        "troubleshoot/plugin/error/other.json",
+        "When Air bending",
+        "troubleshoot/plugin/airbug.json"
     ]
 }


### PR DESCRIPTION
added `airbug,json` file
bot responds with "If you are on minecraft 1.21.9+. make sure `plugins\\Projectkorra\\config.yml`. Has Path `Air.Particles` set to `CLOUD`. then save and run `\\b reload`." to `.airbug` and `.airparticles`
added airbug option to `error.json`